### PR TITLE
Simplify blog authoring by using static HTML posts

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,8 +21,8 @@ A single-page futuristic blog built entirely with HTML and CSS. Every post lives
 ## Write a new post
 
 1. Open `index.html` in any text editor.
-2. Find the `<section class="post-list">` element.
-3. Copy one of the `<article class="post-card">` blocks and paste it where you want the new story to appear (newest at the top).
+2. Find the `<section class="post-list">` element and duplicate one of the `<article class="post-card">` blocks inside it.
+3. Paste the copy where you want the new story to appear (keep the newest entries nearest the top).
 4. Update the contents:
    - The `<h2>` headline.
    - The `<time>` element text and its `datetime="YYYY-MM-DD"` attribute.

--- a/README.md
+++ b/README.md
@@ -1,2 +1,68 @@
-# blog
-cool blog
+# Neon Constellation Blog
+
+A single-page futuristic blog built entirely with HTML and CSS. Every post lives right inside `index.html`, so updating your writing feels as simple as editing a document.
+
+## Features
+
+- **Futuristic design** – neon gradients, glassmorphism cards, and smooth hover effects.
+- **No JavaScript editing** – type your stories directly into HTML `<article>` blocks.
+- **Instant results** – save and refresh to see your new post, no build step required.
+
+## Project structure
+
+```
+.
+├── index.html          # main page and your posts
+└── assets
+    └── css
+        └── main.css    # futuristic styling
+```
+
+## Write a new post
+
+1. Open `index.html` in any text editor.
+2. Find the `<section class="post-list">` element.
+3. Copy one of the `<article class="post-card">` blocks and paste it where you want the new story to appear (newest at the top).
+4. Update the contents:
+   - The `<h2>` headline.
+   - The `<time>` element text and its `datetime="YYYY-MM-DD"` attribute.
+   - The teaser paragraph with class `excerpt`.
+   - The paragraphs inside `<div class="body">`. Add more `<p>` elements if you need them.
+5. Save the file and refresh your browser to view the post immediately.
+
+> **Tip:** Draft in any editor you like—when you're ready, paste your words directly between the `<p>` tags.
+
+## Preview locally
+
+Because everything is static HTML and CSS, you can simply double-click `index.html` to open it in your browser. For a more realistic preview (with the same URL you will deploy), you can also run any simple static server, but it is optional.
+
+## Host it for free
+
+Because the blog is just static files, you can deploy it almost anywhere. Three easy options:
+
+### 1. GitHub Pages
+
+1. Push this repository to GitHub.
+2. In the GitHub UI, go to **Settings → Pages**.
+3. Choose the `main` (or whichever) branch, set the root folder, and save.
+4. GitHub will provide a public URL after the first build (usually within a minute).
+
+### 2. Netlify Drop
+
+1. Zip the project folder or drag it directly into <https://app.netlify.com/drop>.
+2. Netlify uploads the files and instantly returns a live URL.
+3. Whenever you update posts, drag the folder again to redeploy.
+
+### 3. Vercel
+
+1. Install the [Vercel CLI](https://vercel.com/docs/cli) or connect the GitHub repo inside the Vercel dashboard.
+2. Choose “Other” when asked for the project framework.
+3. Deploy – Vercel detects it’s a static site and serves it globally with a CDN.
+
+## Customize the look
+
+- Change fonts or colors inside `assets/css/main.css`.
+- Adjust the glow effects by tweaking the `.background-glow` gradients.
+- Customize hover behavior in the `.post-card` styles.
+
+Have fun filling the galaxy with your stories!

--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -235,7 +235,7 @@ main {
   font-size: clamp(1.8rem, 3vw, 2.4rem);
 }
 
-.instructions {
+.instructions { 
   margin: 0 0 18px;
   padding-left: 20px;
   line-height: 1.8;
@@ -248,6 +248,17 @@ main {
   border-radius: 6px;
   background: rgba(124, 154, 255, 0.15);
   border: 1px solid rgba(124, 154, 255, 0.25);
+}
+
+.instructions ul {
+  margin: 12px 0 0;
+  padding-left: 20px;
+  list-style: square;
+  color: rgba(216, 226, 255, 0.9);
+}
+
+.instructions ul li {
+  margin: 6px 0;
 }
 
 .site-footer {

--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -1,0 +1,289 @@
+:root {
+  color-scheme: dark;
+  --bg: #030314;
+  --fg: #f5f9ff;
+  --muted: #8fa3ff;
+  --accent: linear-gradient(120deg, #7f5bff, #22d3ee 55%, #f973ff 110%);
+  --card-bg: rgba(13, 17, 48, 0.75);
+  --border-glow: rgba(124, 154, 255, 0.35);
+  --shadow: 0 25px 60px rgba(10, 13, 35, 0.45);
+  --mono: 'IBM Plex Mono', ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas,
+    'Liberation Mono', 'Courier New', monospace;
+  --sans: 'Space Grotesk', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI',
+    sans-serif;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+html,
+body {
+  margin: 0;
+  padding: 0;
+  font-family: var(--sans);
+  background: var(--bg);
+  color: var(--fg);
+  min-height: 100%;
+  scroll-behavior: smooth;
+}
+
+body {
+  position: relative;
+  overflow-x: hidden;
+}
+
+.background-glow {
+  position: fixed;
+  inset: -25vh -25vw;
+  z-index: -2;
+  background: radial-gradient(circle at 20% 20%, rgba(125, 105, 255, 0.6), transparent 55%),
+    radial-gradient(circle at 80% 35%, rgba(37, 208, 255, 0.6), transparent 50%),
+    radial-gradient(circle at 50% 80%, rgba(249, 115, 255, 0.55), transparent 60%);
+  filter: blur(60px);
+  transform: translateZ(0);
+}
+
+.background-grid {
+  position: fixed;
+  inset: 0;
+  background-image: linear-gradient(
+      rgba(255, 255, 255, 0.07) 1px,
+      transparent 1px
+    ),
+    linear-gradient(90deg, rgba(255, 255, 255, 0.07) 1px, transparent 1px);
+  background-size: 80px 80px;
+  mask-image: radial-gradient(circle at center, rgba(0, 0, 0, 0.65), transparent 70%);
+  z-index: -3;
+}
+
+.container {
+  width: min(960px, 92vw);
+  margin: 0 auto;
+}
+
+.site-header {
+  position: sticky;
+  top: 0;
+  backdrop-filter: blur(12px);
+  background: rgba(3, 3, 20, 0.65);
+  border-bottom: 1px solid rgba(124, 154, 255, 0.2);
+  z-index: 10;
+  box-shadow: 0 18px 40px rgba(0, 0, 0, 0.45);
+}
+
+.site-header .container {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  padding: 30px 0 24px;
+}
+
+.logo {
+  font-size: clamp(1.6rem, 3vw, 2.25rem);
+  font-weight: 700;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  background: var(--accent);
+  -webkit-background-clip: text;
+  background-clip: text;
+  color: transparent;
+}
+
+.tagline {
+  margin: 0;
+  color: var(--muted);
+  font-size: 1rem;
+  letter-spacing: 0.03em;
+}
+
+.site-nav {
+  display: flex;
+  gap: 12px;
+  flex-wrap: wrap;
+}
+
+.pill {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 10px 18px;
+  border-radius: 999px;
+  border: 1px solid rgba(255, 255, 255, 0.2);
+  color: inherit;
+  text-decoration: none;
+  font-size: 0.85rem;
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+  transition: border-color 0.2s ease, box-shadow 0.2s ease, transform 0.2s ease;
+  position: relative;
+  overflow: hidden;
+}
+
+.pill::before {
+  content: '';
+  position: absolute;
+  inset: 0;
+  background: var(--accent);
+  opacity: 0;
+  transition: opacity 0.2s ease;
+  z-index: -1;
+}
+
+.pill:hover,
+.pill:focus {
+  border-color: rgba(255, 255, 255, 0.6);
+  box-shadow: 0 0 18px rgba(125, 105, 255, 0.45);
+  transform: translateY(-2px);
+}
+
+.pill:hover::before,
+.pill:focus::before {
+  opacity: 0.35;
+}
+
+main {
+  padding: 120px 0 64px;
+  display: flex;
+  flex-direction: column;
+  gap: 32px;
+}
+
+.intro-card,
+.info-card,
+.post-card {
+  background: var(--card-bg);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  border-radius: 28px;
+  padding: clamp(24px, 5vw, 42px);
+  position: relative;
+  overflow: hidden;
+  box-shadow: var(--shadow);
+  isolation: isolate;
+}
+
+.intro-card::after,
+.info-card::after,
+.post-card::after {
+  content: '';
+  position: absolute;
+  inset: 1px;
+  border-radius: inherit;
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  pointer-events: none;
+}
+
+.intro-card h1 {
+  font-size: clamp(2.4rem, 5vw, 3.2rem);
+  margin-bottom: 18px;
+  letter-spacing: 0.04em;
+}
+
+.intro-card p {
+  margin: 0;
+  max-width: 48ch;
+  line-height: 1.65;
+  color: rgba(223, 231, 255, 0.85);
+}
+
+.post-list {
+  display: grid;
+  gap: 28px;
+}
+
+.post-card {
+  transition: transform 0.3s ease, box-shadow 0.3s ease;
+}
+
+.post-card:hover {
+  transform: translateY(-4px);
+  box-shadow: 0 30px 60px rgba(10, 13, 35, 0.6);
+}
+
+.post-card h2 {
+  margin: 0 0 16px;
+  font-size: clamp(1.8rem, 3vw, 2.3rem);
+  letter-spacing: 0.02em;
+}
+
+.post-card time {
+  font-family: var(--mono);
+  font-size: 0.85rem;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: rgba(189, 202, 255, 0.78);
+}
+
+.post-card .excerpt {
+  color: rgba(230, 236, 255, 0.9);
+  margin: 14px 0 24px;
+  line-height: 1.6;
+}
+
+.post-card .body p {
+  line-height: 1.75;
+  color: rgba(216, 226, 255, 0.9);
+  margin: 0 0 16px;
+}
+
+.post-card .body p:last-child {
+  margin-bottom: 0;
+}
+
+.info-card h2 {
+  margin-top: 0;
+  font-size: clamp(1.8rem, 3vw, 2.4rem);
+}
+
+.instructions {
+  margin: 0 0 18px;
+  padding-left: 20px;
+  line-height: 1.8;
+}
+
+.instructions code {
+  font-family: var(--mono);
+  font-size: 0.85rem;
+  padding: 2px 6px;
+  border-radius: 6px;
+  background: rgba(124, 154, 255, 0.15);
+  border: 1px solid rgba(124, 154, 255, 0.25);
+}
+
+.site-footer {
+  padding: 48px 0 64px;
+  color: rgba(193, 206, 255, 0.65);
+  text-align: center;
+  font-size: 0.9rem;
+}
+
+.site-footer p {
+  margin: 0;
+}
+
+@media (min-width: 720px) {
+  .site-header .container {
+    flex-direction: row;
+    align-items: center;
+    justify-content: space-between;
+  }
+
+  .tagline {
+    font-size: 1.05rem;
+  }
+
+  .site-nav {
+    gap: 16px;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.01ms !important;
+    scroll-behavior: auto !important;
+  }
+}

--- a/index.html
+++ b/index.html
@@ -1,0 +1,135 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Neon Constellation Blog</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@400;500;700&family=IBM+Plex+Mono:wght@400;600&display=swap"
+      rel="stylesheet"
+    />
+    <link rel="stylesheet" href="assets/css/main.css" />
+  </head>
+  <body>
+    <div class="background-glow" aria-hidden="true"></div>
+    <div class="background-grid" aria-hidden="true"></div>
+    <header class="site-header">
+      <div class="container">
+        <div class="logo">Neon Constellation</div>
+        <p class="tagline">Thoughts from the edge of tomorrow.</p>
+        <nav class="site-nav" aria-label="Site navigation">
+          <a href="#posts" class="pill">Posts</a>
+          <a href="#about" class="pill">About</a>
+          <a href="#write" class="pill">Write your own</a>
+        </nav>
+      </div>
+    </header>
+
+    <main class="container" id="posts">
+      <section class="intro-card">
+        <h1>Welcome to your futuristic blog</h1>
+        <p>
+          Every post lives right in this HTML file now—no JavaScript data files or
+          tooling to worry about. Duplicate a card, write your story, and the neon
+          styling takes care of the rest.
+        </p>
+      </section>
+
+      <section class="post-list" aria-label="Blog posts">
+        <article class="post-card">
+          <h2>Welcome to the Constellation</h2>
+          <time datetime="2024-05-12">May 12, 2024</time>
+          <p class="excerpt">
+            Charting the course of this experimental blog and how to add your own cosmic thoughts.
+          </p>
+          <div class="body">
+            <p>
+              This demo post shows you how your writing will look inside the neon interface.
+            </p>
+            <p>
+              Use the instructions below to create as many posts as you like. The cards automatically
+              arrange themselves exactly as you order them in the markup, so keep the newest at the top.
+            </p>
+            <p>
+              Sprinkle in <strong>bold highlights</strong> or <code>inline code</code> directly in the HTML—no special syntax needed.
+            </p>
+          </div>
+        </article>
+
+        <article class="post-card">
+          <h2>Signal From the Aurora</h2>
+          <time datetime="2024-04-20">April 20, 2024</time>
+          <p class="excerpt">
+            An imaginary dispatch from a research station floating above the north pole.
+          </p>
+          <div class="body">
+            <p>
+              A green ribbon of light folds across the sky, weaving a network that dances between the magnetic field lines.
+            </p>
+            <p>
+              We route transmissions through the aurora now. The plasma reflects every emotion, every curiosity, every plan for what comes next.
+            </p>
+            <p>
+              And it all started because someone decided to write down their observations.
+            </p>
+          </div>
+        </article>
+      </section>
+    </main>
+
+    <section class="container" id="about">
+      <article class="info-card">
+        <h2>About this project</h2>
+        <p>
+          Neon Constellation is designed to feel like a portal into the future. It
+          uses glowing layers, glassmorphism, and cosmic gradients to showcase your
+          writing.
+        </p>
+        <p>
+          Everything runs in the browser with zero dependencies. Each story is
+          just an <code>&lt;article&gt;</code> block inside <code>index.html</code>.
+        </p>
+      </article>
+    </section>
+
+    <section class="container" id="write">
+      <article class="info-card">
+        <h2>Write a new entry</h2>
+        <ol class="instructions">
+          <li>Open <code>index.html</code> in any text editor.</li>
+          <li>
+            Duplicate one of the <code>&lt;article class="post-card"&gt;</code>
+            blocks inside the <code>&lt;section class="post-list"&gt;</code>
+            element.
+          </li>
+          <li>
+            Update the heading, <code>&lt;time&gt;</code> element (including the
+            <code>datetime</code> attribute), the teaser paragraph, and the
+            paragraphs inside <code>&lt;div class="body"&gt;</code>.
+          </li>
+          <li>
+            Keep your newest story toward the top of the list. The order in the
+            HTML is exactly how the page renders it.
+          </li>
+          <li>
+            Save the file and refresh your browser to see the update
+            immediately.
+          </li>
+        </ol>
+        <p>
+          Ready to share with the world? Check the README for simple hosting
+          options like GitHub Pages or Netlify.
+        </p>
+      </article>
+    </section>
+
+    <footer class="site-footer">
+      <div class="container">
+        <p>Crafted in the future. Built with pure HTML and CSS.</p>
+      </div>
+    </footer>
+
+  </body>
+</html>

--- a/index.html
+++ b/index.html
@@ -100,21 +100,32 @@
         <ol class="instructions">
           <li>Open <code>index.html</code> in any text editor.</li>
           <li>
-            Duplicate one of the <code>&lt;article class="post-card"&gt;</code>
-            blocks inside the <code>&lt;section class="post-list"&gt;</code>
-            element.
+            Inside the <code>&lt;section class="post-list"&gt;</code>, duplicate
+            an existing <code>&lt;article class="post-card"&gt;</code> block and
+            paste it where you want the new entry to appear.
           </li>
           <li>
-            Update the heading, <code>&lt;time&gt;</code> element (including the
-            <code>datetime</code> attribute), the teaser paragraph, and the
-            paragraphs inside <code>&lt;div class="body"&gt;</code>.
+            Replace the placeholder content:
+            <ul>
+              <li>The <code>&lt;h2&gt;</code> title.</li>
+              <li>
+                The <code>&lt;time&gt;</code> text <em>and</em> its
+                <code>datetime="YYYY-MM-DD"</code> attribute.
+              </li>
+              <li>The teaser paragraph with class <code>excerpt</code>.</li>
+              <li>
+                The body paragraphs inside
+                <code>&lt;div class="body"&gt;</code>. Add more
+                <code>&lt;p&gt;</code> elements if you need them.
+              </li>
+            </ul>
           </li>
           <li>
-            Keep your newest story toward the top of the list. The order in the
-            HTML is exactly how the page renders it.
+            Keep the newest story closest to the top of the list. Posts render
+            in the exact order they appear in the HTML.
           </li>
           <li>
-            Save the file and refresh your browser to see the update
+            Save the file and refresh your browser to see your update
             immediately.
           </li>
         </ol>


### PR DESCRIPTION
## Summary
- remove the JavaScript-based post renderer so entries live directly in the HTML
- adjust styling to work without intersection observers while keeping futuristic hover effects
- rewrite the README with the simpler editing workflow and updated project structure

## Testing
- not run (static site)


------
https://chatgpt.com/codex/tasks/task_e_68cc64c00ae88331b8870f7e70c130af