### PR TITLE
Align hosting copy with updated README

### DIFF
--- a/index.html
+++ b/index.html
@@ -87,8 +87,9 @@
           </li>
         </ol>
         <p>
-          Ready to distribute to the resistance? Check the README for simple
-          hosting options like GitHub Pages or Netlify.
+          Ready to distribute to the resistance? Package these static files and
+          deploy them to any host that serves plain HTML—GitHub Pages, Netlify,
+          or your own bunker server will all work.
         </p>
       </article>
     </section>


### PR DESCRIPTION
## Summary
- update the call-to-action in the "Log a new entry" panel so it no longer points to removed README hosting guidance
- clarify that the static files can be deployed to any static host

## Testing
- no tests were run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68cd7e276f688331beb34ff57eb531d9