### PR TITLE
Strip homepage content

### DIFF
--- a/index.html
+++ b/index.html
@@ -17,8 +17,6 @@
     <div class="background-grid" aria-hidden="true"></div>
     <header class="site-header">
       <div class="container">
-        <div class="logo">YoRHa Archives</div>
-        <p class="tagline">Operational logs from humanity's last bastion.</p>
         <nav class="site-nav" aria-label="Site navigation">
           <a href="#posts" class="pill">Posts</a>
           <a href="#about" class="pill">About</a>
@@ -27,80 +25,8 @@
       </div>
     </header>
 
-    <main class="container" id="posts">
-      <section class="intro-card">
-        <h1>Welcome to the Bunker archive</h1>
-        <p>
-          This single-page archive is tuned for decrypted YoRHa transmissions.
-          Update one file and watch the mission logs render with stark lines,
-          operator marks, and that familiar monochrome glow.
-        </p>
-      </section>
-
-      <section class="post-list" aria-live="polite"></section>
-    </main>
-
-    <section class="container" id="about">
-      <article class="info-card">
-        <h2>About this terminal</h2>
-        <p>
-          The YoRHa Archives theme strips away neon futurism in favor of desolate
-          sepia tones, mechanical borders, and utilitarian typography. It's meant
-          to evoke the briefing rooms of the Bunker.
-        </p>
-        <p>
-          Everything still runs in the browser with zero dependencies. Only a
-          single JavaScript file controls the feed of mission reports and
-          operator notes.
-        </p>
-      </article>
-    </section>
-
-    <section class="container" id="write">
-      <article class="info-card">
-        <h2>Log a new entry</h2>
-        <ol class="instructions">
-          <li>Open <code>assets/js/posts.js</code> in your preferred terminal.</li>
-          <li>
-            Append a fresh object to <code>window.BLOG_POSTS</code>. Give it
-            <code>title</code>, <code>date</code>, <code>excerpt</code>, and
-            <code>body</code> properties just like the existing entries—for
-            example:
-            <pre><code>window.BLOG_POSTS.push({
-  title: "Unit 2B Debrief",
-  date: "11945-04-05",
-  excerpt: "Short-range recon near the Flooded City.",
-  body: "Initial scan revealed..."
-});</code></pre>
-          </li>
-          <li>
-            Use ISO date format (<code>YYYY-MM-DD</code>) so the command console
-            keeps the logs in order.
-          </li>
-          <li>
-            Separate paragraphs in the <code>body</code> with a blank line. The
-            site converts them into clean HTML for you.
-          </li>
-          <li>
-            Save the file and refresh the page. Your transmission will appear
-            instantly.
-          </li>
-        </ol>
-        <p>
-          Ready to distribute to the resistance? Package these static files and
-          deploy them to any host that serves plain HTML—GitHub Pages, Netlify,
-          or your own bunker server will all work.
-        </p>
-      </article>
-    </section>
-
-    <footer class="site-footer">
-      <div class="container">
-        <p>Glory to mankind. Built with pure HTML, CSS, and JavaScript.</p>
-      </div>
-    </footer>
-
-    <script src="assets/js/posts.js"></script>
-    <script src="assets/js/app.js" type="module"></script>
+    <div id="posts" hidden></div>
+    <div id="about" hidden></div>
+    <div id="write" hidden></div>
   </body>
 </html>


### PR DESCRIPTION
## Summary
- remove all homepage sections so only the navigation buttons remain visible
- add hidden anchor targets to preserve the Posts/About/Write navigation links without showing content

## Testing
- not run (static site)

------
https://chatgpt.com/codex/tasks/task_e_68cdd5d29a508331be14706c86126d2f