### PR TITLE
Show only hi everybody post

### DIFF
--- a/assets/js/posts.js
+++ b/assets/js/posts.js
@@ -1,8 +1,7 @@
 window.BLOG_POSTS = [
   {
-    title: "Simple Greeting",
+    title: "hi everybody",
     date: "2024-06-02",
-    excerpt: "A quick hello to everyone reading.",
     body: "hi everybody",
   },
 ];

--- a/index.html
+++ b/index.html
@@ -15,70 +15,11 @@
   <body>
     <div class="background-glow" aria-hidden="true"></div>
     <div class="background-grid" aria-hidden="true"></div>
-    <header class="site-header">
-      <div class="container">
-        <div>
-          <a class="logo" href="#posts">YoRHa Archives</a>
-          <p class="tagline">Mission logs from the bunker command archive</p>
-        </div>
-        <nav class="site-nav" aria-label="Site navigation">
-          <a href="#posts" class="pill">Posts</a>
-          <a href="#about" class="pill">About</a>
-          <a href="#write" class="pill">Write your own</a>
-        </nav>
-      </div>
-    </header>
-
     <main>
       <div class="container">
-        <section id="posts" class="intro-card" aria-labelledby="posts-heading">
-          <h1 id="posts-heading">Latest transmissions</h1>
-          <p>
-            Pull up a chair in the command center. These archived dispatches from the
-            YoRHa bunker fade in as soon as they're decrypted.
-          </p>
-        </section>
-
         <section class="post-list" aria-live="polite"></section>
-
-        <section id="about" class="info-card" aria-labelledby="about-heading">
-          <h2 id="about-heading">About the archives</h2>
-          <p>
-            YoRHa Archives is a lightweight static journal inspired by the terminal
-            readouts used by the android forces in the bunker. Entries are rendered
-            directly in the browser—no database, no build step.
-          </p>
-          <p>
-            Update <code>assets/js/posts.js</code> and refresh the page to decrypt new
-            field reports.
-          </p>
-        </section>
-
-        <section id="write" class="info-card" aria-labelledby="write-heading">
-          <h2 id="write-heading">Write your own log</h2>
-          <p>
-            Add a new object to <code>window.BLOG_POSTS</code> and include these
-            fields:
-          </p>
-          <ol class="instructions">
-            <li><strong>title</strong> – the operation name or headline.</li>
-            <li><strong>date</strong> – timestamp in <code>YYYY-MM-DD</code> format.</li>
-            <li><strong>excerpt</strong> – a short teaser for the mission.</li>
-            <li>
-              <strong>body</strong> – the full briefing. Separate paragraphs with a
-              blank line; use <code>**bold**</code> and <code>`code`</code> for
-              emphasis.
-            </li>
-          </ol>
-        </section>
       </div>
     </main>
-
-    <footer class="site-footer">
-      <div class="container">
-        <p>Glory to mankind.</p>
-      </div>
-    </footer>
 
     <script src="assets/js/posts.js"></script>
     <script src="assets/js/app.js" type="module"></script>


### PR DESCRIPTION
## Summary
- remove all page sections except for the blog post list so only entries render
- keep only the "hi everybody" post data and drop the extra excerpt text

## Testing
- not run (static site; no automated tests provided)

------
https://chatgpt.com/codex/tasks/task_e_68d1685fbd6083318371a03561f6a021