### PR TITLE
Fix blog post date display for timezone consistency

### DIFF
--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -39,16 +39,46 @@ if (!posts.length) {
 }
 
 function formatDate(isoString) {
-  const date = new Date(isoString);
-  if (Number.isNaN(date.getTime())) {
+  if (!isoString) {
+    return '';
+  }
+
+  let date;
+
+  if (isoString instanceof Date) {
+    date = isoString;
+  } else if (typeof isoString === 'string') {
+    const match = isoString.match(/^(\d{4})-(\d{2})-(\d{2})$/);
+
+    if (match) {
+      const [, yearStr, monthStr, dayStr] = match;
+      const year = Number(yearStr);
+      const month = Number(monthStr);
+      const day = Number(dayStr);
+
+      if (
+        Number.isNaN(year) ||
+        Number.isNaN(month) ||
+        Number.isNaN(day)
+      ) {
+        return isoString;
+      }
+
+      date = new Date(year, month - 1, day);
+    } else {
+      date = new Date(isoString);
+    }
+  }
+
+  if (!(date instanceof Date) || Number.isNaN(date.getTime())) {
     return isoString;
   }
 
-  return date.toLocaleDateString(undefined, {
+  return new Intl.DateTimeFormat(undefined, {
     year: 'numeric',
     month: 'long',
     day: 'numeric',
-  });
+  }).format(date);
 }
 
 function renderBody(raw) {


### PR DESCRIPTION
## Summary
- ensure YYYY-MM-DD post dates are interpreted as calendar dates to prevent timezone shifts
- retain graceful fallbacks for invalid or unexpected date values

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68d7182c84b08331b668b9447ef3541d