### PR TITLE
Simplify layout to show only posts

### DIFF
--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -1,13 +1,12 @@
 :root {
   color-scheme: light;
-  --bg: #f4f1e7;
-  --fg: #221f1b;
+  --bg: #f5f2ea;
+  --fg: #231f1b;
   --muted: #5f594f;
   --accent: #c8b682;
-  --accent-soft: rgba(200, 182, 130, 0.16);
-  --card-bg: rgba(255, 253, 248, 0.82);
-  --border: rgba(45, 41, 36, 0.35);
-  --shadow: 0 18px 38px rgba(33, 28, 22, 0.14);
+  --card-bg: #fffaf0;
+  --border: rgba(35, 31, 27, 0.12);
+  --shadow: 0 12px 24px rgba(35, 31, 27, 0.12);
   --mono: 'Source Code Pro', ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas,
     'Liberation Mono', 'Courier New', monospace;
   --serif: 'Spectral', 'Iowan Old Style', 'Palatino Linotype', 'URW Palladio L',
@@ -27,299 +26,35 @@ body {
   background: var(--bg);
   color: var(--fg);
   min-height: 100%;
-  scroll-behavior: smooth;
-  cursor: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24"><rect x="10" y="0" width="4" height="24" fill="%23221f1b"/><rect x="0" y="10" width="24" height="4" fill="%23221f1b"/><rect x="8" y="8" width="8" height="8" fill="none" stroke="%23221f1b" stroke-width="2"/></svg>') 12 12, auto;
 }
 
 body {
-  position: relative;
-  overflow-x: hidden;
-  line-height: 1.7;
-}
-
-/* CRT Scanlines */
-body::before {
-  content: '';
-  position: fixed;
-  inset: 0;
-  background: repeating-linear-gradient(
-    0deg,
-    rgba(0, 0, 0, 0.03) 0px,
-    transparent 1px,
-    transparent 2px,
-    rgba(0, 0, 0, 0.03) 3px
-  );
-  pointer-events: none;
-  z-index: 9999;
-  animation: scanlines 8s linear infinite;
-}
-
-@keyframes scanlines {
-  0% { transform: translateY(0); }
-  100% { transform: translateY(4px); }
-}
-
-/* Noise grain texture */
-body::after {
-  content: '';
-  position: fixed;
-  inset: 0;
-  background-image: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" width="200" height="200"><filter id="noise"><feTurbulence type="fractalNoise" baseFrequency="0.9" numOctaves="4" stitchTiles="stitch"/></filter><rect width="100%" height="100%" filter="url(%23noise)" opacity="0.08"/></svg>');
-  pointer-events: none;
-  z-index: 9998;
-  opacity: 0.4;
-  animation: grain-shift 6s steps(8) infinite;
-}
-
-@keyframes grain-shift {
-  0% {
-    transform: translate3d(0, 0, 0) scale(1.02);
-  }
-  50% {
-    transform: translate3d(-2%, 1%, 0) scale(1.03);
-  }
-  100% {
-    transform: translate3d(1%, -1%, 0) scale(1.01);
-  }
-}
-
-.background-glow {
-  position: fixed;
-  inset: -30vh -30vw;
-  z-index: -2;
-  background: radial-gradient(
-      circle at 18% 25%,
-      rgba(224, 214, 186, 0.85),
-      transparent 55%
-    ),
-    radial-gradient(
-      circle at 82% 35%,
-      rgba(191, 181, 157, 0.7),
-      transparent 50%
-    ),
-    radial-gradient(
-      circle at 40% 82%,
-      rgba(214, 204, 179, 0.65),
-      transparent 60%
-    );
-  filter: blur(110px);
-  transform: translateZ(0);
-  animation: glow-pulse 12s ease-in-out infinite;
-}
-
-@keyframes glow-pulse {
-  0%, 100% { opacity: 1; }
-  50% { opacity: 0.7; }
-}
-
-.background-grid {
-  position: fixed;
-  inset: 0;
-  background-image: linear-gradient(rgba(32, 28, 24, 0.07) 1px, transparent 1px),
-    linear-gradient(90deg, rgba(32, 28, 24, 0.07) 1px, transparent 1px);
-  background-size: 120px 120px;
-  mask-image: radial-gradient(
-    circle at center,
-    rgba(0, 0, 0, 0.55),
-    transparent 80%
-  );
-  z-index: -3;
-  animation: grid-shift 20s linear infinite;
-}
-
-@keyframes grid-shift {
-  0% { transform: translate(0, 0); }
-  100% { transform: translate(120px, 120px); }
-}
-
-.container {
-  width: min(960px, 92vw);
-  margin: 0 auto;
-}
-
-.site-header {
-  position: sticky;
-  top: 0;
-  backdrop-filter: blur(8px);
-  background: rgba(244, 241, 231, 0.92);
-  border-bottom: 2px solid rgba(33, 29, 25, 0.18);
-  z-index: 10;
-  box-shadow: 0 12px 28px rgba(25, 21, 18, 0.18);
-}
-
-.site-header .container {
   display: flex;
-  flex-direction: column;
-  gap: 16px;
-  padding: 28px 0 22px;
-}
-
-.brand {
-  display: flex;
-  flex-direction: column;
-  gap: 6px;
-}
-
-.logo {
-  font-family: var(--display);
-  font-size: clamp(1.8rem, 3.2vw, 2.7rem);
-  font-weight: 500;
-  letter-spacing: 0.12em;
-  text-transform: uppercase;
-  color: var(--fg);
-  position: relative;
-  padding-bottom: 6px;
-  text-shadow: 2px 2px 0 rgba(200, 182, 130, 0.3);
-}
-
-.logo::after {
-  content: '';
-  position: absolute;
-  left: 0;
-  bottom: 0;
-  width: 68px;
-  height: 2px;
-  background: var(--accent);
-  animation: border-pulse 3s ease-in-out infinite;
-}
-
-@keyframes border-pulse {
-  0%, 100% { width: 68px; opacity: 1; }
-  50% { width: 88px; opacity: 0.7; }
-}
-
-.tagline {
-  margin: 0;
-  color: var(--muted);
-  font-size: 1rem;
-  letter-spacing: 0.08em;
-  text-transform: uppercase;
-}
-
-.site-nav {
-  display: flex;
-  gap: 12px;
-  flex-wrap: wrap;
-}
-
-.pill {
-  display: inline-flex;
-  align-items: center;
   justify-content: center;
-  padding: 8px 18px;
-  border-radius: 999px;
-  border: 1px solid rgba(40, 36, 30, 0.35);
-  background: rgba(255, 253, 246, 0.6);
-  color: inherit;
-  text-decoration: none;
-  font-size: 0.75rem;
-  text-transform: uppercase;
-  letter-spacing: 0.18em;
-  transition: background 0.2s ease, transform 0.2s ease, border-color 0.2s ease;
-  cursor: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24"><rect x="0" y="0" width="24" height="24" fill="%23c8b682"/></svg>') 12 12, pointer;
-}
-
-.pill:hover,
-.pill:focus {
-  border-color: rgba(38, 33, 27, 0.6);
-  background: rgba(200, 182, 130, 0.25);
-  transform: translateY(-1px);
-  box-shadow: 0 4px 12px rgba(200, 182, 130, 0.3);
 }
 
 main {
-  padding: 112px 0 64px;
-  display: flex;
-  flex-direction: column;
-  gap: 32px;
+  flex: 1;
+  padding: clamp(2rem, 4vw, 4rem) 0;
 }
 
-.intro-card,
-.info-card,
-.post-card {
-  background: var(--card-bg);
-  border: 1px solid var(--border);
-  border-radius: 18px;
-  padding: clamp(24px, 5vw, 42px);
-  position: relative;
-  overflow: hidden;
-  box-shadow: var(--shadow);
-  isolation: isolate;
-  transition: transform 0.3s ease, box-shadow 0.3s ease;
-}
-
-.intro-card:hover,
-.info-card:hover,
-.post-card:hover {
-  transform: translateY(-2px);
-  box-shadow: 0 22px 48px rgba(33, 28, 22, 0.2);
-}
-
-/* Animated borders */
-.intro-card::before,
-.info-card::before,
-.post-card::before {
-  content: '';
-  position: absolute;
-  inset: -2px;
-  border-radius: 18px;
-  padding: 2px;
-  background: linear-gradient(135deg, 
-    transparent,
-    rgba(200, 182, 130, 0.4),
-    transparent
-  );
-  mask: linear-gradient(#fff 0 0) content-box, linear-gradient(#fff 0 0);
-  mask-composite: exclude;
-  opacity: 0;
-  transition: opacity 0.4s ease;
-  pointer-events: none;
-}
-
-.intro-card:hover::before,
-.info-card:hover::before,
-.post-card:hover::before {
-  opacity: 1;
-  animation: border-shimmer 2s linear infinite;
-}
-
-@keyframes border-shimmer {
-  0% { background-position: 0% 0%; }
-  100% { background-position: 200% 200%; }
-}
-
-.intro-card::after,
-.info-card::after,
-.post-card::after {
-  content: '';
-  position: absolute;
-  inset: 8px;
-  border-radius: calc(18px - 8px);
-  border: 1px solid rgba(48, 42, 36, 0.12);
-  pointer-events: none;
-}
-
-.intro-card h1 {
-  font-family: var(--display);
-  font-size: clamp(2.3rem, 5vw, 3.1rem);
-  margin-bottom: 18px;
-  letter-spacing: 0.14em;
-  text-transform: uppercase;
-}
-
-.intro-card p {
-  margin: 0;
-  max-width: 48ch;
-  line-height: 1.7;
-  color: rgba(55, 48, 41, 0.88);
+.container {
+  width: min(720px, 92vw);
+  margin: 0 auto;
 }
 
 .post-list {
   display: grid;
-  gap: 28px;
+  gap: clamp(1.5rem, 3vw, 2.5rem);
 }
 
 .post-card {
+  position: relative;
+  padding: clamp(1.5rem, 3vw, 2.25rem);
+  border-radius: 18px;
+  background: var(--card-bg);
+  border: 1px solid var(--border);
+  box-shadow: var(--shadow);
   transform: translateY(24px);
   opacity: 0;
   transition: transform 0.6s ease, opacity 0.6s ease;
@@ -330,167 +65,108 @@ main {
   opacity: 1;
 }
 
-/* Glitch effect class */
+.post-card::after {
+  content: '';
+  position: absolute;
+  inset: 10px;
+  border-radius: 12px;
+  border: 1px solid rgba(35, 31, 27, 0.08);
+  pointer-events: none;
+}
+
+.post-card h2 {
+  font-family: var(--display);
+  font-size: clamp(1.6rem, 3vw, 2.1rem);
+  margin: 0 0 0.5rem;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+}
+
+time {
+  display: inline-block;
+  font-family: var(--mono);
+  font-size: 0.9rem;
+  letter-spacing: 0.08em;
+  color: var(--muted);
+  margin-bottom: 1rem;
+}
+
+.excerpt {
+  margin: 0 0 1.25rem;
+  font-size: 1.05rem;
+  line-height: 1.7;
+  color: rgba(35, 31, 27, 0.84);
+}
+
+.body p {
+  margin: 0 0 1.15rem;
+  line-height: 1.8;
+}
+
+.body p:last-child {
+  margin-bottom: 0;
+}
+
+.body code {
+  font-family: var(--mono);
+  font-size: 0.95rem;
+  background: rgba(35, 31, 27, 0.06);
+  border-radius: 6px;
+  padding: 0.2rem 0.4rem;
+}
+
 .glitch {
   position: relative;
-  animation: glitch-anim 3s infinite;
+  display: inline-block;
+  text-shadow: 2px 2px 0 rgba(200, 182, 130, 0.35);
 }
 
 .glitch::before,
 .glitch::after {
   content: attr(data-text);
   position: absolute;
-  top: 0;
-  left: 0;
-  width: 100%;
-  height: 100%;
+  inset: 0;
+  pointer-events: none;
   opacity: 0;
 }
 
 .glitch::before {
-  animation: glitch-before 3s infinite;
-  color: rgba(200, 182, 130, 0.8);
-  z-index: -1;
+  color: rgba(200, 182, 130, 0.85);
+  transform: translate(-2px, 0);
 }
 
 .glitch::after {
-  animation: glitch-after 3s infinite;
-  color: rgba(95, 89, 79, 0.8);
-  z-index: -2;
+  color: rgba(95, 89, 79, 0.75);
+  transform: translate(2px, 0);
 }
 
-@keyframes glitch-anim {
-  0%, 98%, 100% { transform: translate(0); }
-  99% { transform: translate(-2px, 2px); }
+.post-card:hover .glitch::before {
+  opacity: 0.6;
+  animation: glitch-shift-left 1.4s infinite;
 }
 
-@keyframes glitch-before {
-  0%, 3%, 5%, 42%, 44%, 55%, 100% { opacity: 0; transform: translate(0); }
-  4% { opacity: 0.7; transform: translate(-2px, -2px); }
-  43% { opacity: 0.7; transform: translate(2px, 2px); }
+.post-card:hover .glitch::after {
+  opacity: 0.6;
+  animation: glitch-shift-right 1.4s infinite;
 }
 
-@keyframes glitch-after {
-  0%, 3%, 5%, 42%, 44%, 55%, 100% { opacity: 0; transform: translate(0); }
-  4% { opacity: 0.7; transform: translate(2px, 0); }
-  43% { opacity: 0.7; transform: translate(-2px, 0); }
-}
-
-.post-card h2 {
-  font-family: var(--display);
-  margin: 0 0 16px;
-  font-size: clamp(1.7rem, 3vw, 2.2rem);
-  letter-spacing: 0.12em;
-  text-transform: uppercase;
-}
-
-.post-card time {
-  font-family: var(--mono);
-  font-size: 0.75rem;
-  letter-spacing: 0.36em;
-  text-transform: uppercase;
-  color: rgba(65, 60, 52, 0.75);
-  display: inline-block;
-  padding: 6px 10px;
-  border: 1px solid rgba(45, 40, 34, 0.25);
-  background: rgba(238, 233, 222, 0.6);
-  margin-bottom: 18px;
-}
-
-.post-card .excerpt {
-  color: rgba(51, 45, 39, 0.85);
-  margin: 14px 0 24px;
-  line-height: 1.65;
-  font-style: italic;
-}
-
-.post-card .body p {
-  line-height: 1.75;
-  color: rgba(49, 43, 37, 0.88);
-  margin: 0 0 16px;
-}
-
-.post-card .body p:last-child {
-  margin-bottom: 0;
-}
-
-.post-card .body strong {
-  font-weight: 600;
-  letter-spacing: 0.05em;
-}
-
-.info-card h2 {
-  font-family: var(--display);
-  margin-top: 0;
-  font-size: clamp(1.6rem, 3vw, 2.2rem);
-  letter-spacing: 0.1em;
-  text-transform: uppercase;
-}
-
-.instructions {
-  margin: 0 0 18px;
-  padding-left: 20px;
-  line-height: 1.8;
-  list-style: square;
-}
-
-.instructions li {
-  margin-bottom: 8px;
-}
-
-.instructions li:last-child {
-  margin-bottom: 0;
-}
-
-.instructions code,
-.post-card code,
-.intro-card code,
-.info-card code {
-  font-family: var(--mono);
-  font-size: 0.85rem;
-  padding: 2px 6px;
-  border-radius: 4px;
-  background: rgba(32, 27, 21, 0.08);
-  border: 1px solid rgba(32, 27, 21, 0.15);
-  color: rgba(38, 33, 27, 0.82);
-}
-
-/* Chromatic aberration effect on hover */
-.post-card:hover h2 {
-  animation: chromatic-aberration 0.3s ease-out;
-}
-
-@keyframes chromatic-aberration {
-  0%, 100% { text-shadow: none; }
-  25% { text-shadow: -2px 0 rgba(200, 182, 130, 0.5), 2px 0 rgba(95, 89, 79, 0.5); }
-  50% { text-shadow: -3px 0 rgba(200, 182, 130, 0.7), 3px 0 rgba(95, 89, 79, 0.7); }
-  75% { text-shadow: -2px 0 rgba(200, 182, 130, 0.5), 2px 0 rgba(95, 89, 79, 0.5); }
-}
-
-.site-footer {
-  padding: 48px 0 64px;
-  color: rgba(67, 60, 52, 0.75);
-  text-align: center;
-  font-size: 0.9rem;
-}
-
-.site-footer p {
-  margin: 0;
-}
-
-@media (min-width: 720px) {
-  .site-header .container {
-    flex-direction: row;
-    align-items: center;
-    justify-content: space-between;
+@keyframes glitch-shift-left {
+  0%,
+  100% {
+    transform: translate(-2px, 0);
   }
-
-  .tagline {
-    font-size: 0.95rem;
+  50% {
+    transform: translate(2px, 0);
   }
+}
 
-  .site-nav {
-    gap: 16px;
+@keyframes glitch-shift-right {
+  0%,
+  100% {
+    transform: translate(2px, 0);
+  }
+  50% {
+    transform: translate(-2px, 0);
   }
 }
 
@@ -501,14 +177,5 @@ main {
     animation-duration: 0.01ms !important;
     animation-iteration-count: 1 !important;
     transition-duration: 0.01ms !important;
-    scroll-behavior: auto !important;
-  }
-  
-  body::before,
-  body::after,
-  .background-glow,
-  .background-grid,
-  .logo::after {
-    animation: none !important;
   }
 }

--- a/index.html
+++ b/index.html
@@ -13,54 +13,11 @@
     <link rel="stylesheet" href="assets/css/main.css" />
   </head>
   <body>
-    <div class="background-glow" aria-hidden="true"></div>
-    <div class="background-grid" aria-hidden="true"></div>
-
-    <header class="site-header">
-      <div class="container">
-        <div class="brand">
-          <span class="logo" aria-label="velvetdaemon">velvetdaemon</span>
-          <p class="tagline">Analog transmissions from the terminal void</p>
-        </div>
-        <nav class="site-nav" aria-label="Primary navigation">
-          <a class="pill" href="#posts">Posts</a>
-          <a class="pill" href="#manifesto">Manifesto</a>
-          <a class="pill" href="#toolkit">Toolkit</a>
-        </nav>
-      </div>
-    </header>
-
     <main>
       <div class="container">
-        <section class="intro-card" id="manifesto">
-          <h1 class="glitch" data-text="Field Notes from the Terminal">
-            Field Notes from the Terminal
-          </h1>
-          <p>
-            Broadcasting fragments, rituals, and analog dreams from a flickering
-            command line future. Tune in for speculative essays, cultural
-            dispatches, and the occasional systems breach.
-          </p>
-        </section>
-
-        <section class="info-card" id="toolkit" aria-labelledby="toolkit-title">
-          <h2 id="toolkit-title">Operator Toolkit</h2>
-          <ul class="instructions">
-            <li>Deploy the <code>.glitch</code> class with a <code>data-text</code> attribute for instant signal distortion.</li>
-            <li>Hover over cards to trigger shimmering borders, chromatic drifts, and elevated shadows.</li>
-            <li>Point anywhere to wield the custom crosshair cursor crafted for terminal explorers.</li>
-          </ul>
-        </section>
-
         <section class="post-list" id="posts" aria-live="polite"></section>
       </div>
     </main>
-
-    <footer class="site-footer">
-      <div class="container">
-        <p>© <span id="current-year"></span> velvetdaemon — Signals never sleep.</p>
-      </div>
-    </footer>
 
     <script src="assets/js/posts.js"></script>
     <script src="assets/js/app.js" type="module"></script>


### PR DESCRIPTION
## Summary
- remove non-post sections from the landing page so only the post list remains
- streamline the stylesheet to keep styling focused on the post list and glitch titles

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dedb41ecb08331bf3a57b8df7d36dc