### PR TITLE
Remove glitch animations and header cursor

### DIFF
--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -205,56 +205,6 @@ time {
   position: relative;
   display: inline-block;
   text-shadow: 0 0 10px rgba(245, 207, 135, 0.35);
-  transition: text-shadow 0.3s ease;
-}
-
-.glitch::before,
-.glitch::after {
-  content: attr(data-text);
-  position: absolute;
-  inset: 0;
-  pointer-events: none;
-  opacity: 0;
-}
-
-.glitch::before {
-  color: rgba(245, 207, 135, 0.85);
-  transform: translate(-2px, 0);
-}
-
-.glitch::after {
-  color: rgba(162, 142, 110, 0.75);
-  transform: translate(2px, 0);
-}
-
-.post-card:hover .glitch::before {
-  opacity: 0.6;
-  animation: glitch-shift-left 1.4s infinite;
-}
-
-.post-card:hover .glitch::after {
-  opacity: 0.6;
-  animation: glitch-shift-right 1.4s infinite;
-}
-
-@keyframes glitch-shift-left {
-  0%,
-  100% {
-    transform: translate(-2px, 0);
-  }
-  50% {
-    transform: translate(2px, 0);
-  }
-}
-
-@keyframes glitch-shift-right {
-  0%,
-  100% {
-    transform: translate(2px, 0);
-  }
-  50% {
-    transform: translate(-2px, 0);
-  }
 }
 
 .cursor-target {

--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -1,45 +1,12 @@
 const posts = Array.isArray(window.BLOG_POSTS) ? [...window.BLOG_POSTS] : [];
 const postList = document.querySelector('.post-list');
-const reduceMotionQuery = window.matchMedia
-  ? window.matchMedia('(prefers-reduced-motion: reduce)')
-  : null;
-let reduceMotion = reduceMotionQuery ? reduceMotionQuery.matches : false;
-const corruptibleElements = new Set();
-const scheduledCorruptions = new Map();
-const activeCorruptions = new Map();
-const GLITCH_CHARS = '!<>-_\\/[]{}=+*^?#%$&';
 
 if (document.body) {
   document.body.classList.add('has-js');
 }
 
-if (reduceMotionQuery) {
-  const handler = (event) => {
-    reduceMotion = event.matches;
-    if (reduceMotion) {
-      scheduledCorruptions.forEach((timeoutId) => window.clearTimeout(timeoutId));
-      scheduledCorruptions.clear();
-      activeCorruptions.forEach((state, element) => {
-        if (state) {
-          state.cancelled = true;
-        }
-        const original = element.dataset.originalText || element.textContent;
-        element.textContent = original;
-        element.setAttribute('data-text', original);
-      });
-      activeCorruptions.clear();
-    } else {
-      corruptibleElements.forEach((element) => scheduleRandomCorruption(element));
-    }
-  };
-  if (typeof reduceMotionQuery.addEventListener === 'function') {
-    reduceMotionQuery.addEventListener('change', handler);
-  } else if (typeof reduceMotionQuery.addListener === 'function') {
-    reduceMotionQuery.addListener(handler);
-  }
-}
 if (!posts.length) {
-  postList.innerHTML = `<article class="post-card"><h2 class="glitch cursor-target-block" data-text="No posts yet">No posts yet</h2><p class="excerpt cursor-target-block">Add your first story by editing <code>assets/js/posts.js</code>.</p></article>`;
+  postList.innerHTML = `<article class="post-card"><h2 class="glitch">No posts yet</h2><p class="excerpt cursor-target-block">Add your first story by editing <code>assets/js/posts.js</code>.</p></article>`;
 } else {
   posts
     .filter((post) => post && post.title && post.date)
@@ -48,8 +15,7 @@ if (!posts.length) {
       const card = document.createElement('article');
       card.className = 'post-card';
       const title = document.createElement('h2');
-      title.className = 'glitch cursor-target-block';
-      title.setAttribute('data-text', post.title);
+      title.className = 'glitch';
       title.textContent = post.title;
       card.appendChild(title);
       const meta = document.createElement('time');
@@ -150,10 +116,6 @@ cards.forEach((card) => {
   if (!card.hasAttribute('tabindex')) {
     card.tabIndex = 0;
   }
-  const headings = card.querySelectorAll('.glitch');
-  headings.forEach((element) => registerCorruptible(element));
-  const glitchableText = card.querySelectorAll('.excerpt, .body p');
-  glitchableText.forEach((element) => registerCorruptible(element));
 });
 
 const currentYearEl = document.getElementById('current-year');
@@ -164,86 +126,3 @@ if (currentYearEl) {
 requestAnimationFrame(() => {
   document.body.classList.add('is-loaded');
 });
-
-function registerCorruptible(element) {
-  if (!element || corruptibleElements.has(element)) {
-    return;
-  }
-  if (element.childElementCount > 0) {
-    return;
-  }
-  const originalText = element.textContent;
-  if (!originalText || !originalText.trim()) {
-    return;
-  }
-  element.dataset.originalText = originalText;
-  corruptibleElements.add(element);
-  const handler = () => triggerCorruption(element);
-  element.addEventListener('mouseenter', handler);
-  element.addEventListener('focus', handler);
-  if (!reduceMotion) {
-    scheduleRandomCorruption(element);
-  }
-}
-
-function triggerCorruption(element) {
-  if (!element || activeCorruptions.has(element) || reduceMotion) {
-    return;
-  }
-  const originalText = element.dataset.originalText || element.textContent;
-  if (!originalText) {
-    return;
-  }
-  const totalFrames = Math.max(24, originalText.length * 3);
-  let frame = 0;
-  const originalChars = [...originalText];
-  const animationState = { cancelled: false };
-  activeCorruptions.set(element, animationState);
-
-  const animate = () => {
-    if (animationState.cancelled) {
-      return;
-    }
-    frame += 1;
-    const progress = frame / totalFrames;
-    const revealCount = Math.floor(originalChars.length * Math.min(progress * 1.15, 1));
-    const nextText = originalChars
-      .map((char, index) => {
-        if (index < revealCount) {
-          return char;
-        }
-        const randomIndex = Math.floor(Math.random() * GLITCH_CHARS.length);
-        return GLITCH_CHARS[randomIndex] || char;
-      })
-      .join('');
-    element.textContent = nextText;
-    element.setAttribute('data-text', nextText);
-    if (frame < totalFrames) {
-      requestAnimationFrame(animate);
-    } else {
-      element.textContent = originalText;
-      element.setAttribute('data-text', originalText);
-      activeCorruptions.delete(element);
-    }
-  };
-
-  animate();
-}
-
-function scheduleRandomCorruption(element) {
-  if (!element || reduceMotion) {
-    return;
-  }
-  const minDelay = 6000;
-  const maxDelay = 14000;
-  const timeoutDuration = Math.floor(Math.random() * (maxDelay - minDelay) + minDelay);
-  const existingTimeout = scheduledCorruptions.get(element);
-  if (existingTimeout) {
-    window.clearTimeout(existingTimeout);
-  }
-  const timeoutId = window.setTimeout(() => {
-    triggerCorruption(element);
-    scheduleRandomCorruption(element);
-  }, timeoutDuration);
-  scheduledCorruptions.set(element, timeoutId);
-}


### PR DESCRIPTION
## Summary
- remove the glitch animation logic and associated styles so post text stays steady
- drop the cursor-target styling from headers to keep the cursor blink off titles while preserving it elsewhere

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68defadb7afc8331878c4aeb4623ea42