### PR TITLE
Center archive layout and trim copy

### DIFF
--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -40,6 +40,8 @@ body {
 body {
   display: flex;
   justify-content: center;
+  align-items: center;
+  min-height: 100vh;
   position: relative;
   overflow-x: hidden;
   transition: background 1.2s ease;
@@ -98,7 +100,8 @@ html::before {
 }
 
 main {
-  flex: 1;
+  flex: 0 1 auto;
+  width: min(720px, 92vw);
   padding: clamp(2rem, 4vw, 4rem) 0;
   position: relative;
   z-index: 1;

--- a/index.html
+++ b/index.html
@@ -14,32 +14,8 @@
   </head>
   <body>
     <main>
-      <header class="page-hero">
-        <h1 class="page-title">velvetdaemon</h1>
-        <p class="page-hero__tagline">
-          Dispatches from a spectral cinema—notes, fragments, and other curios.
-        </p>
-        <a class="page-hero__cta" href="#posts">Enter the archive</a>
-      </header>
-      <div class="container">
-        <section class="post-list" id="posts" aria-live="polite"></section>
-      </div>
+      <section class="post-list" id="posts" aria-live="polite"></section>
     </main>
-
-    <footer class="site-footer">
-      <div class="container site-footer__inner">
-        <p>
-          © <span id="current-year"></span> velvetdaemon. Crafted in the void with
-          <span aria-hidden="true">✧</span>
-        </p>
-        <nav aria-label="Social links">
-          <ul class="site-footer__links">
-            <li><a href="https://letterboxd.com/000_leo/">Letterboxd</a></li>
-            <li><a href="mailto:velvetdaemon@example.com">Email</a></li>
-          </ul>
-        </nav>
-      </div>
-    </footer>
 
     <script src="assets/js/posts.js"></script>
     <script src="assets/js/app.js" type="module"></script>


### PR DESCRIPTION
## Summary
- remove hero and footer copy to keep the archive focused on posts
- center the post grid within the viewport for a symmetrical layout

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e53b1386708331ba4b1852d46f8c0a