### PR TITLE
Fix post layout clipping when posts overflow the viewport

### DIFF
--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -39,7 +39,8 @@ body {
 
 body {
   display: flex;
-  justify-content: center;
+  flex-direction: column;
+  justify-content: flex-start;
   align-items: center;
   min-height: 100vh;
   position: relative;


### PR DESCRIPTION
## Summary
- adjust the body flex layout to stack content vertically
- align the page content to the top so longer posts are no longer clipped

## Testing
- not run (static site)


------
https://chatgpt.com/codex/tasks/task_e_68e53e3ff04c8331ad73dcd5c6267c1a